### PR TITLE
[TOOLS-4438] replace tinfo.so.x LINK to dynamic library loading at runtime (dlopen)

### DIFF
--- a/src/terminal.c
+++ b/src/terminal.c
@@ -376,7 +376,7 @@ terminal_end(EditLine *el)
         if (dl_handle != NULL) {
                 dlclose(dl_handle);
                 dl_handle = NULL;
-	}					        }
+	}
 
 	el_free(el->el_terminal.t_buf);
 	el->el_terminal.t_buf = NULL;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -289,37 +289,37 @@ terminal_init(EditLine *el)
 
 	if (dl_handle == NULL){
 		fprintf (stderr, "ERROR: Cannot load tinfo library. Please install tinfo library.\n");
-		goto fail1;
+		_exit(127);
 	}
 
 	if ((tgoto = dlsym(dl_handle, "tgoto")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgoto' function in %s.\n", tinfo_so);
-		goto fail1;
+		_exit(127);
 	}
 
 	if ((tgetent = dlsym(dl_handle, "tgetent")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetent' function in %s.\n", tinfo_so);
-		goto fail1;
+		_exit(127);
 	}
 
 	if ((tgetflag = dlsym(dl_handle, "tgetflag")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetflag' function in %s.\n", tinfo_so);
-		goto fail1;
+		_exit(127);
 	}
 
 	if ((tgetnum = dlsym(dl_handle, "tgetnum")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetnum' function in %s.\n", tinfo_so);
-		goto fail1;
+		_exit(127);
 	}
 
 	if ((tgetstr = dlsym(dl_handle, "tgetstr")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetstr' function in %s.\n", tinfo_so);
-		goto fail1;
+		_exit(127);
 	}
 
 	if ((tputs = dlsym(dl_handle, "tputs")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tputs' function in %s.\n", tinfo_so);
-		goto fail1;
+		_exit(127);
 	}
 
 	el->el_terminal.t_buf = el_malloc(TC_BUFSIZE *

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -82,8 +82,8 @@ int (*tgetnum) (char *id);
 char *(*tgetstr) (char *id, char **area);
 int (*tputs) (const char *str, int affcnt, int (*putc)(int));
 
-#define	NCURSES_HIGH_VERSION	10
-#define	NCURSES_LOW_VERSION	5
+#define	TINFO_HIGH_VERSION	10
+#define	TINFO_LOW_VERSION	5
 
 /*
  * IMPORTANT NOTE: these routines are allowed to look at the current screen
@@ -281,14 +281,14 @@ terminal_init(EditLine *el)
 	char tinfo_so[TC_BUFSIZE];
 	int major_version;
 
-	for (major_version = NCURSES_HIGH_VERSION; major_version >= NCURSES_LOW_VERSION; major_version--){
+	for (major_version = TINFO_HIGH_VERSION; major_version >= TINFO_LOW_VERSION; major_version--){
 		sprintf (tinfo_so, "libtinfo.so.%d", major_version);
 		if ((dl_handle = dlopen (tinfo_so, RTLD_LAZY)) != NULL)
 			break;
 	}
 
 	if (dl_handle == NULL){
-		fprintf (stderr, "ERROR: Cannot load ncurses library.\n");
+		fprintf (stderr, "ERROR: Cannot load tinfo library. Please install tinfo library.\n");
 		goto fail1;
 	}
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -294,26 +294,32 @@ terminal_init(EditLine *el)
 
 	if ((tgoto = dlsym(dl_handle, "tgoto")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgoto' function in %s.\n", tinfo_so);
+		goto fail1;
 	}
 
 	if ((tgetent = dlsym(dl_handle, "tgetent")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetent' function in %s.\n", tinfo_so);
+		goto fail1;
 	}
 
 	if ((tgetflag = dlsym(dl_handle, "tgetflag")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetflag' function in %s.\n", tinfo_so);
+		goto fail1;
 	}
 
 	if ((tgetnum = dlsym(dl_handle, "tgetnum")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetnum' function in %s.\n", tinfo_so);
+		goto fail1;
 	}
 
 	if ((tgetstr = dlsym(dl_handle, "tgetstr")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tgetstr' function in %s.\n", tinfo_so);
+		goto fail1;
 	}
 
 	if ((tputs = dlsym(dl_handle, "tputs")) == NULL){
 		fprintf (stderr, "ERROR: Cannot find 'tputs' function in %s.\n", tinfo_so);
+		goto fail1;
 	}
 
 	el->el_terminal.t_buf = el_malloc(TC_BUFSIZE *


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4438

**Purpose**
* replace **libtinfo.so** link to runtime dynamic library loading by dlopen ()

**Implementation**

**Remarks**
* idea & original code was written by @mhoh3963 
* it is for removing curses major version dependancy