### PR TITLE
[TOOLS-4439] Update for TAB key handling

### DIFF
--- a/src/el.h
+++ b/src/el.h
@@ -48,7 +48,6 @@
 #define	KSHVI
 #endif
 
-#if !def
 #define	VIDEFAULT
 #define	ANCHOR
 

--- a/src/el.h
+++ b/src/el.h
@@ -42,7 +42,6 @@
 /*
  * Local defaults
  */
-#define	KSHVI
 #define	VIDEFAULT
 #define	ANCHOR
 

--- a/src/el.h
+++ b/src/el.h
@@ -42,6 +42,13 @@
 /*
  * Local defaults
  */
+#define	CUBRID_CSQL
+
+#ifndef CUBRID_CSQL
+#define	KSHVI
+#endif
+
+#if !def
 #define	VIDEFAULT
 #define	ANCHOR
 

--- a/src/map.c
+++ b/src/map.c
@@ -384,7 +384,11 @@ static const el_action_t  el_map_vi_insert[] = {
 	/*   6 */	ED_NEXT_CHAR,		/* ^F */
 	/*   7 */	ED_UNASSIGNED,		/* ^G */
 	/*   8 */	VI_DELETE_PREV_CHAR,	/* ^H */   /* BackSpace key */
+#ifdef CUBRID_CSQL
 	/*   9 */	ED_INSERT,		/* ^I */   /* Tab Key */
+#else
+	/*   9 */	ED_UNASSIGNED,		/* ^I */   /* Tab Key */
+#endif
 	/*  10 */	ED_NEWLINE,		/* ^J */
 	/*  11 */	ED_KILL_LINE,		/* ^K */
 	/*  12 */	ED_CLEAR_SCREEN,	/* ^L */

--- a/src/map.c
+++ b/src/map.c
@@ -384,7 +384,7 @@ static const el_action_t  el_map_vi_insert[] = {
 	/*   6 */	ED_NEXT_CHAR,		/* ^F */
 	/*   7 */	ED_UNASSIGNED,		/* ^G */
 	/*   8 */	VI_DELETE_PREV_CHAR,	/* ^H */   /* BackSpace key */
-	/*   9 */	ED_UNASSIGNED,		/* ^I */   /* Tab Key */
+	/*   9 */	ED_INSERT,		/* ^I */   /* Tab Key */
 	/*  10 */	ED_NEWLINE,		/* ^J */
 	/*  11 */	ED_KILL_LINE,		/* ^K */
 	/*  12 */	ED_CLEAR_SCREEN,	/* ^L */

--- a/src/readline.c
+++ b/src/readline.c
@@ -325,20 +325,11 @@ rl_initialize(void)
 
 	/* set default mode to "emacs"-style and read setting afterwards */
 	/* so this can be overridden */
-	el_set(e, EL_EDITOR, "emacs");
+	el_set(e, EL_EDITOR, "vi");
 	if (rl_terminal_name != NULL)
 		el_set(e, EL_TERMINAL, rl_terminal_name);
 	else
 		el_get(e, EL_TERMINAL, &rl_terminal_name);
-
-	/*
-	 * Word completion - this has to go AFTER rebinding keys
-	 * to emacs-style.
-	 */
-	el_set(e, EL_ADDFN, "rl_complete",
-	    "ReadLine compatible completion function",
-	    _el_rl_complete);
-	el_set(e, EL_BIND, "^I", "rl_complete", NULL);
 
 	/*
 	 * Send TSTP when ^Z is pressed.

--- a/src/readline.c
+++ b/src/readline.c
@@ -325,11 +325,26 @@ rl_initialize(void)
 
 	/* set default mode to "emacs"-style and read setting afterwards */
 	/* so this can be overridden */
+#ifdef CUBRID_CSQL
 	el_set(e, EL_EDITOR, "vi");
+#else
+	el_set(e, EL_EDITOR, "emacs");
+#endif
 	if (rl_terminal_name != NULL)
 		el_set(e, EL_TERMINAL, rl_terminal_name);
 	else
 		el_get(e, EL_TERMINAL, &rl_terminal_name);
+
+#ifndef CUBRID_CSQL
+	/*
+	 * Word completion - this has to go AFTER rebinding keys
+	 * to emacs-style.
+	 */
+	el_set(e, EL_ADDFN, "rl_complete",
+	    "ReadLine compatible completion function",
+	    _el_rl_complete);
+	el_set(e, EL_BIND, "^I", "rl_complete", NULL);
+#endif
 
 	/*
 	 * Send TSTP when ^Z is pressed.


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4439

**Purpose**
* **csql** modification requirements
* modify **libedit** to output the tab key as it is

**Implementation**

**Remarks**
Currently, the list directory command is executed when the tab key is pressed twice.