### PR TITLE
[TOOLS-4444] restore keyboard profile from vi to emacs

### DIFF
--- a/src/el.h
+++ b/src/el.h
@@ -44,10 +44,7 @@
  */
 #define	CUBRID_CSQL
 
-#ifndef CUBRID_CSQL
 #define	KSHVI
-#endif
-
 #define	VIDEFAULT
 #define	ANCHOR
 

--- a/src/map.c
+++ b/src/map.c
@@ -76,7 +76,11 @@ static const el_action_t  el_map_emacs[] = {
 	/*   6 */	ED_NEXT_CHAR,		/* ^F */
 	/*   7 */	ED_UNASSIGNED,		/* ^G */
 	/*   8 */	EM_DELETE_PREV_CHAR,	/* ^H */
+#if defined (CUBRID_CSQL)
+	/*   9 */	ED_INSERT,		/* ^I */
+#else
 	/*   9 */	ED_UNASSIGNED,		/* ^I */
+#endif
 	/*  10 */	ED_NEWLINE,		/* ^J */
 	/*  11 */	ED_KILL_LINE,		/* ^K */
 	/*  12 */	ED_CLEAR_SCREEN,	/* ^L */

--- a/src/readline.c
+++ b/src/readline.c
@@ -325,11 +325,8 @@ rl_initialize(void)
 
 	/* set default mode to "emacs"-style and read setting afterwards */
 	/* so this can be overridden */
-#ifdef CUBRID_CSQL
-	el_set(e, EL_EDITOR, "vi");
-#else
 	el_set(e, EL_EDITOR, "emacs");
-#endif
+
 	if (rl_terminal_name != NULL)
 		el_set(e, EL_TERMINAL, rl_terminal_name);
 	else


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4444

**Description**
* restore keyboard profile for libedit-for-CUBRID to 'emacs'

**Implementation**

Remarks